### PR TITLE
Add demo script and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,26 @@
 
 CIELO (Cloud Infrastructure, Environment, and Lifecycle Orchestrator) is a modular Django project.
 
-This initial bootstrap provides a server-rendered interface using Bootstrap 5 and prepares the project for future API and React frontend integration.
+This bootstrap provides a server-rendered interface using Bootstrap 5 and prepares the project for future API and React frontend integration.
+
+## Requirements
+
+- Python 3.12
+- [Poetry](https://python-poetry.org/)
+
+## Setup
+
+1. Clone this repository.
+2. Install dependencies with `poetry install`.
+3. Optional: create an admin user with `poetry run python manage.py createsuperuser`.
+
+## Running the Demo
+
+A helper script `start_demo.sh` is included to initialize the project and launch the development server.
+
+```bash
+./start_demo.sh
+```
+
+The script will run database migrations and start the Django site at http://localhost:8000/. After it starts, open your browser and visit that URL to explore the demo.
+

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Ensure poetry is installed
+if ! command -v poetry >/dev/null 2>&1; then
+  echo "Poetry is required. Please install it first." >&2
+  exit 1
+fi
+
+# Install dependencies
+poetry install
+
+# Apply database migrations
+poetry run python manage.py migrate --noinput
+
+# Start the development server
+echo "Starting CIELO at http://localhost:8000/"
+poetry run python manage.py runserver 0.0.0.0:8000
+


### PR DESCRIPTION
## Summary
- document setup instructions in the README
- add `start_demo.sh` helper script for running the demo

## Testing
- `pytest -q`