### PR TITLE
Add password change enforcement for default admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This bootstrap provides a server-rendered interface using Bootstrap 5 and prepar
 1. Clone this repository.
 2. Install dependencies with `poetry install`.
 3. Optional: create an admin user with `poetry run python manage.py createsuperuser`.
+   On first run the project automatically creates a default administrator with
+   username `admin` and password `admin`. When logging in with these defaults you
+   will be required to change the password unless the environment variable
+   `CIELO_DEPLOYMENT` is set to `development` or `dev`.
 
 ## Running the Demo
 

--- a/cielo_core/urls.py
+++ b/cielo_core/urls.py
@@ -1,10 +1,9 @@
 from django.contrib import admin
 from django.urls import path, include
-from django.contrib.auth import views as auth_views
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('login/', auth_views.LoginView.as_view(template_name='users/login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    path('', include('users.urls')),
     path('', include('inventory.urls')),
 ]

--- a/users/apps.py
+++ b/users/apps.py
@@ -1,5 +1,18 @@
 from django.apps import AppConfig
+import os
+from django.contrib.auth import get_user_model
+from django.db.utils import OperationalError, ProgrammingError
 
 class UsersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'users'
+
+    def ready(self):
+        deployment = os.environ.get('CIELO_DEPLOYMENT', '').lower()
+        try:
+            User = get_user_model()
+            if not User.objects.filter(username='admin').exists():
+                User.objects.create_superuser('admin', 'admin@example.com', 'admin')
+        except (OperationalError, ProgrammingError):
+            # Database might not be ready during migration commands
+            pass

--- a/users/templates/users/change_password.html
+++ b/users/templates/users/change_password.html
@@ -1,0 +1,14 @@
+{% extends 'common/base.html' %}
+{% block title %}Change Password{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <h2 class="text-center">Change Password</h2>
+    <form method="post" class="card p-4">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit" class="btn btn-primary w-100">Update Password</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+from django.contrib.auth.views import LogoutView
+from .views import CieloLoginView, CieloPasswordChangeView
+
+app_name = 'users'
+
+urlpatterns = [
+    path('login/', CieloLoginView.as_view(), name='login'),
+    path('logout/', LogoutView.as_view(), name='logout'),
+    path('change-password/', CieloPasswordChangeView.as_view(), name='change_password'),
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.views import LoginView, PasswordChangeView
+from django.urls import reverse
+import os
+
+
+class CieloLoginView(LoginView):
+    template_name = 'users/login.html'
+
+    def get_success_url(self):
+        user = self.request.user
+        deployment = os.environ.get('CIELO_DEPLOYMENT', '').lower()
+        if (
+            user.username == 'admin'
+            and user.check_password('admin')
+            and deployment not in ('development', 'dev')
+        ):
+            return reverse('users:change_password')
+        return super().get_success_url()
+
+
+class CieloPasswordChangeView(PasswordChangeView):
+    template_name = 'users/change_password.html'
+
+    def get_success_url(self):
+        return reverse('login')


### PR DESCRIPTION
## Summary
- create default admin on startup
- enforce password change for default admin unless CIELO_DEPLOYMENT is development
- add change password form and custom login/password change views
- update URL routing to use custom users app
- document default admin behaviour and environment variable

## Testing
- `poetry run python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*