### PR TITLE
Implement logout page and update login design

### DIFF
--- a/common/templates/common/base_auth.html
+++ b/common/templates/common/base_auth.html
@@ -1,0 +1,27 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en" data-topbar-color="brand">
+    <head>
+        <meta charset="utf-8" />
+        <title>{% block title %}CIELO{% endblock %} | CIELO</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta content="A fully featured admin theme which can be used to build CRM, CMS, etc." name="description" />
+        <meta content="Coderthemes" name="author" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <link rel="shortcut icon" href="{% static 'material_theme/images/favicon.ico' %}">
+        <link href="{% static 'material_theme/css/bootstrap.min.css' %}" rel="stylesheet" type="text/css" />
+        <link href="{% static 'material_theme/css/app.min.css' %}" rel="stylesheet" type="text/css" id="app-stylesheet" />
+        <link href="{% static 'material_theme/css/icons.min.css' %}" rel="stylesheet" type="text/css" />
+        <script src="{% static 'material_theme/js/config.js' %}"></script>
+        {% block extra_head %}{% endblock %}
+    </head>
+    <body>
+        {% block content %}{% endblock %}
+        <footer class="footer footer-alt">
+            <script>document.write(new Date().getFullYear())</script> &copy; CIELO
+        </footer>
+        <script src="{% static 'material_theme/js/vendor.min.js' %}"></script>
+        <script src="{% static 'material_theme/js/app.min.js' %}"></script>
+        {% block extra_js %}{% endblock %}
+    </body>
+</html>

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -1,20 +1,46 @@
-{% extends 'common/base_material.html' %}
+{% extends 'common/base_auth.html' %}
 {% load static %}
 
 {% block title %}Login{% endblock %}
 
-{% block page_title %}Login{% endblock %}
-
 {% block content %}
-<div class="row justify-content-center">
-  <div class="col-md-4">
-    <h1 class="text-center text-primary">CIELO</h1>
-    <p class="text-center">Cloud Infrastructure, Environment, and Lifecycle Orchestrator</p>
-    <form method="post" class="card p-4">
-      {% csrf_token %}
-      {{ form.as_p }}
-      <button type="submit" class="btn btn-primary w-100">Login</button>
-    </form>
+<div class="account-pages mt-5 mb-5">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-8 col-lg-6 col-xl-4">
+        <div class="card">
+          <div class="card-body p-4">
+            <div class="text-center w-75 m-auto">
+              <div class="auth-logo">
+                <a href="{% url 'users:login' %}" class="logo logo-dark text-center">
+                  <span class="logo-lg">
+                    <img src="{% static 'material_theme/images/logo-dark.png' %}" alt="" height="22">
+                  </span>
+                </a>
+                <a href="{% url 'users:login' %}" class="logo logo-light text-center">
+                  <span class="logo-lg">
+                    <img src="{% static 'material_theme/images/logo-light.png' %}" alt="" height="22">
+                  </span>
+                </a>
+              </div>
+              <p class="text-muted mb-4 mt-3">Enter your username and password to access CIELO.</p>
+            </div>
+            <form method="post">
+              {% csrf_token %}
+              {{ form.as_p }}
+              <div class="d-grid mb-0 text-center">
+                <button class="btn btn-primary" type="submit">Log In</button>
+              </div>
+            </form>
+          </div>
+        </div>
+        <div class="row mt-3">
+          <div class="col-12 text-center">
+            <p class="text-muted">Need help? Contact your administrator.</p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/users/templates/users/logout.html
+++ b/users/templates/users/logout.html
@@ -1,0 +1,38 @@
+{% extends 'common/base_auth.html' %}
+{% load static %}
+
+{% block title %}Logged Out{% endblock %}
+
+{% block content %}
+<div class="account-pages mt-5 mb-5">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-8 col-lg-6 col-xl-4">
+        <div class="card">
+          <div class="card-body p-4">
+            <div class="text-center">
+              <div class="mt-4">
+                <div class="logout-checkmark">
+                  <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 161.2 161.2" enable-background="new 0 0 161.2 161.2" xml:space="preserve">
+                    <path class="logout-path" fill="none" stroke="#d1dee4" stroke-miterlimit="10" d="M425.9,52.1L425.9,52.1c-2.2-2.6-6-2.6-8.3-0.1l-42.7,46.2l-14.3-16.4 c-2.3-2.7-6.2-2.7-8.6-0.1c-1.9,2.1-2,5.6-0.1,7.7l17.6,20.3c0.2,0.3,0.4,0.6,0.6,0.9c1.8,2,4.4,2.5,6.6,1.4c0.7-0.3,1.4-0.8,2-1.5 c0.3-0.3,0.5-0.6,0.7-0.9l46.3-50.1C427.7,57.5,427.7,54.2,425.9,52.1z"></path>
+                    <circle class="logout-path" fill="none" stroke="#1abc9c" stroke-width="4" stroke-miterlimit="10" cx="80.6" cy="80.6" r="62.1"></circle>
+                    <polyline class="logout-path" fill="none" stroke="#1abc9c" stroke-width="6" stroke-linecap="round" stroke-miterlimit="10" points="113,52.8 74.1,108.4 48.2,86.4 "></polyline>
+                    <circle class="logout-spin" fill="none" stroke="#d1dee4" stroke-width="4" stroke-miterlimit="10" stroke-dasharray="12.2175,12.2175" cx="80.6" cy="80.6" r="73.9"></circle>
+                  </svg>
+                </div>
+              </div>
+              <h3>See you again !</h3>
+              <p class="text-muted"> You are now successfully signed out. </p>
+            </div>
+          </div>
+        </div>
+        <div class="row mt-3">
+          <div class="col-12 text-center">
+            <p class="text-muted">Back to <a href="{% url 'users:login' %}" class="text-primary fw-medium ms-1">Sign In</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,11 +1,10 @@
 from django.urls import path
-from django.contrib.auth.views import LogoutView
-from .views import CieloLoginView, CieloPasswordChangeView
+from .views import CieloLoginView, CieloLogoutView, CieloPasswordChangeView
 
 app_name = 'users'
 
 urlpatterns = [
     path('login/', CieloLoginView.as_view(), name='login'),
-    path('logout/', LogoutView.as_view(), name='logout'),
+    path('logout/', CieloLogoutView.as_view(), name='logout'),
     path('change-password/', CieloPasswordChangeView.as_view(), name='change_password'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.views import LoginView, PasswordChangeView
+from django.contrib.auth.views import LoginView, LogoutView, PasswordChangeView
 from django.urls import reverse
 import os
 
@@ -23,3 +23,11 @@ class CieloPasswordChangeView(PasswordChangeView):
 
     def get_success_url(self):
         return reverse('users:login')
+
+
+class CieloLogoutView(LogoutView):
+    template_name = 'users/logout.html'
+
+    def get_next_page(self):
+        """Override to render template instead of redirecting."""
+        return None


### PR DESCRIPTION
## Summary
- add `base_auth.html` for simplified authentication pages
- restyle login template using material theme markup
- add new logout template and view
- route logout URL to new view

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a visually enhanced, branded login page with improved layout and instructions.
  - Added a dedicated logout confirmation page with success animation and sign-in link.
  - Implemented a new authentication base template for consistent styling across auth-related pages.

- **Refactor**
  - Updated the login template to use the new authentication base template for a unified look.
  - Modified the logout process to display a confirmation page instead of redirecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->